### PR TITLE
FFM-9485 Use v3 directive in go.mod for fork

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/harness-community/sse/v2
+module github.com/harness-community/sse/v3
 
 go 1.13
 


### PR DESCRIPTION
# What
Use v3 directive for beginning of fork development

# Why
We have introduced a breaking change by updating the go.mod file, plus to easily differntiate between the original r3labs repo