### PR TITLE
FFM-9485 Send empty comments onto the application

### DIFF
--- a/client.go
+++ b/client.go
@@ -344,7 +344,7 @@ func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 		case bytes.HasPrefix(line, headerRetry):
 			e.Retry = append([]byte(nil), trimHeader(len(headerRetry), line)...)
 		case bytes.HasPrefix(line, headerComment):
-			// Don't set a default value for comment, as if it's an empty string then it's a heartbeat event that
+			// Don't set a default value for comment because if it's an empty string then it's a heartbeat event that
 			// we want to forward to the application
 			e.Comment = trimHeader(len(headerComment), line)
 

--- a/client.go
+++ b/client.go
@@ -20,10 +20,11 @@ import (
 )
 
 var (
-	headerID    = []byte("id:")
-	headerData  = []byte("data:")
-	headerEvent = []byte("event:")
-	headerRetry = []byte("retry:")
+	headerID      = []byte("id:")
+	headerData    = []byte("data:")
+	headerEvent   = []byte("event:")
+	headerRetry   = []byte("retry:")
+	headerComment = []byte(":")
 )
 
 func ClientMaxBufferSize(s int) func(c *Client) {
@@ -342,6 +343,11 @@ func (c *Client) processEvent(msg []byte) (event *Event, err error) {
 			e.Event = append([]byte(nil), trimHeader(len(headerEvent), line)...)
 		case bytes.HasPrefix(line, headerRetry):
 			e.Retry = append([]byte(nil), trimHeader(len(headerRetry), line)...)
+		case bytes.HasPrefix(line, headerComment):
+			// Don't set a default value for comment, as if it's an empty string then it's a heartbeat event that
+			// we want to forward to the application
+			e.Comment = trimHeader(len(headerComment), line)
+
 		default:
 			// Ignore any garbage that doesn't match what we're looking for.
 		}

--- a/event.go
+++ b/event.go
@@ -23,7 +23,8 @@ type Event struct {
 }
 
 func (e *Event) hasContent() bool {
-	return len(e.ID) > 0 || len(e.Data) > 0 || len(e.Event) > 0 || len(e.Retry) > 0
+	// If a comment has an empty string, it's a heartbeat and we want to forward it to the application
+	return len(e.ID) > 0 || len(e.Data) > 0 || len(e.Event) > 0 || len(e.Retry) > 0 || string(e.Comment) == ""
 }
 
 // EventStreamReader scans an io.Reader looking for EventStream messages.


### PR DESCRIPTION
# What

If a comment prefix `:` exists, and is empty, then it is a heartbeat event from FF-Server and we want to forward it to the application. 

# Why

So the Go SDK can use the keep alives to detect dead streams. 

# Testing

Manual - FF-Server local with modified keep alives and Go SDK sample app